### PR TITLE
Allow to use mail server self-signed certificates.

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -118,7 +118,14 @@ class Mailbox
             'host' => $this->imapHost,
             'user' => $this->imapLogin,
             'folder' => $this->imapFolder,
-            'password' => $this->imapPassword
+            'password' => $this->imapPassword,
+            'ssl_context_options' => [
+                'ssl' => [
+                    'verify_peer' => true,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true
+                ]
+            ]
         ]);
 
         if (! $imapStream) {


### PR DESCRIPTION
Requres this fix in ParticleBits/zend-mail https://github.com/netandreus/zend-mail/commit/245896be3512e7b8836ed9e8fca9f8d4e2907153